### PR TITLE
Let server die on uncaught exception instead of accumulating leaks.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -34,7 +34,7 @@ function Server(appConfig, userConfig, startUpConfig) {
   util.deepFreeze(userConfig);
   this.startUpConfig = startUpConfig;
   util.deepFreeze(startUpConfig);
-  this.processManager = new ProcessManager();
+  this.processManager = new ProcessManager(true);
   this.authManager = new AuthManager({
     config: userConfig.dataserviceAuthentication,
     productCode:  appConfig.productCode

--- a/js/process.js
+++ b/js/process.js
@@ -27,7 +27,7 @@ function ProcessManager(exitOnException) {
     bootstrapLogger.warn('Uncaught exception found. Error:\n'+err.stack);  
     if (this.exitOnException) {
       bootstrapLogger.warn('Ending server process due to uncaught exception.');
-      process.exit(unp.UNP_EXIT_UNCAUGHT_ERROR);    
+      this.endServer('SIGQUIT');    
     }
   });
   process.on('unhandledRejection', (err) => {


### PR DESCRIPTION
Nodes in cluster get restarts so this exception area should be rare

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>