### PR TITLE
MVD-709 Node server tracing

### DIFF
--- a/js/plugin-loader.js
+++ b/js/plugin-loader.js
@@ -501,8 +501,9 @@ PluginLoader.prototype = {
   },
   
   _readPluginDef(pluginDescriptorFilename) {
-    bootstrapLogger.info(`Processing plugin reference ${pluginDescriptorFilename}...`);
-    const pluginPtrPath = path.join(this.options.pluginsDir, pluginDescriptorFilename);
+    const pluginPtrPath = path.join(this.options.pluginsDir, 
+        pluginDescriptorFilename);
+    bootstrapLogger.info(`Processing plugin reference ${pluginPtrPath}...`);
     if (!fs.existsSync(pluginPtrPath)) {
       throw new Error(`${pluginPtrPath} is missing`);
     }
@@ -528,6 +529,8 @@ PluginLoader.prototype = {
       throw new Error(`No plugin type found for ${pluginDef.identifier} `
       + `found at ${pluginBasePath}, skipping`)
     }
+    bootstrapLogger.info(`Read ${pluginBasePath}: found plugin type `
+        + `'${pluginDef.pluginType}'`);
     this._emitPluginEurekaInfo(pluginDef); // Emit Eureka info
     const pluginConfiguration = configService.getPluginConfiguration(
       pluginDef.identifier, this.options.serverConfig,
@@ -620,9 +623,8 @@ PluginLoader.prototype = {
         plugin.init(pluginContext);
         pluginContext.plugins.push(plugin);
         bootstrapLogger.log(bootstrapLogger.INFO,
-          `Plugin ${plugin.identifier} at path=${plugin.location} loaded\n`);
+          `Plugin ${plugin.identifier} at path=${plugin.location} loaded.\n`);
         bootstrapLogger.debug(' Content:\n' + plugin.toString());
-        console.log('PLUGIN LOCATION: ' + plugin.location);
       } catch (e) {
         console.log(e);
         bootstrapLogger.warn(e)

--- a/js/webserver.js
+++ b/js/webserver.js
@@ -39,6 +39,7 @@ WebServer.prototype = {
     if (this.config.https.pfx) {
       try {
         this.httpsOptions.pfx = fs.readFileSync(this.config.https.pfx);
+        bootstrapLogger.info('Using PFX: '+ this.config.https.pfx);
       } catch (e) {
         bootstrapLogger.warn('Error when reading PFX. Server cannot continue. Error='+e.message);
         //        process.exit(UNP_EXIT_PFX_READ_ERROR);
@@ -46,7 +47,10 @@ WebServer.prototype = {
       }
     } else {
       if (this.config.https.certificates) {
-        this.httpsOptions.cert = util.readFilesToArray(this.config.https.certificates);
+        this.httpsOptions.cert = util.readFilesToArray(
+            this.config.https.certificates);
+        bootstrapLogger.info('Using Certificate: '
+            + this.config.https.certificates);
       }
       if (this.config.https.keys) {
         this.httpsOptions.key = util.readFilesToArray(this.config.https.keys);


### PR DESCRIPTION
Incorporate the changes made by Nathan Drewniak. Slightly modify what
he's done:
 - print the path to the HTTPS certificates
 - more detailed info about plugin loading: print the full path to the
reference and to the plugin folder, print the plugin type

Based on: https://github.com/gizafoundation/zlux-proxy-server/pull/30

Signed-off-by: Fyodor Kovin <fkovin@rocketsoftware.com>