### PR TITLE
Imports were failing when the name of both were not identical

### DIFF
--- a/js/webapp.js
+++ b/js/webapp.js
@@ -838,7 +838,7 @@ WebApp.prototype = {
         if (!pluginRouters) {
           pluginRouters = this.routers[plugin.identifier] = {};
         }
-        pluginRouters[importedService.sourceName] = importedRouter;
+        pluginRouters[importedService.localName] = importedRouter;
       }
     }
   },


### PR DESCRIPTION
Imports were failing when the name of both were not identical due to wrong variable being used

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>