### PR TITLE
Removing dead code that resulted in pointless warnings

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -228,8 +228,7 @@ Server.prototype = {
       serverConfig: this.userConfig,
       staticPlugins: {
         list: this.pluginLoader.plugins,
-        pluginMap: this.pluginLoader.pluginMap,
-        ng2: this.pluginLoader.ng2
+        pluginMap: this.pluginLoader.pluginMap
       },
       newPluginHandler: (pluginDef) => this.newPluginSubmitted(pluginDef),
       auth: webauth

--- a/js/webapp.js
+++ b/js/webapp.js
@@ -99,15 +99,6 @@ function sendAuthorizationFailure(res, authType, resource) {
 };
 
 const staticHandlers = {
-  ng2TypeScript: function(ng2Ts) { 
-    return function(req, res) {
-      contentLogger.log(contentLogger.FINER,"generated ng2 module:\n"+util.inspect(ng2Ts));
-      res.setHeader("Content-Type", "text/typescript");
-      res.setHeader("Server", "jdmfws");
-      res.status(200).send(ng2Ts);
-    }
-  },
-
   plugins: function(plugins) {
     return function(req, res) {
       let parsedRequest = url.parse(req.url, true);
@@ -481,9 +472,6 @@ WebApp.prototype = {
   },
   
   installStaticHanders() {
-    this.expressApp.get(
-      `/${this.options.productCode}/plugins/com.rs.mvd/services/com.rs.mvd.ng2.module.ts`,
-      staticHandlers.ng2TypeScript(this.options.staticPlugins.ng2));
     const webdir = path.join(path.join(this.options.productDir,
       this.options.productCode), 'web');
     const rootPage = this.options.rootRedirectURL? this.options.rootRedirectURL 


### PR DESCRIPTION
It appears that the ng2 module logic was an attempt at some early ideas on how to build a web desktop, that were not needed as a result of adoption of webpack, resulting in some dead code that printed warnings a lot.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>