### PR TITLE
Proxy exception logging fix

### DIFF
--- a/js/proxy.js
+++ b/js/proxy.js
@@ -55,7 +55,7 @@ function convertOptions(request, realHost, realPort, urlPrefix) {
 
 function makeSimpleProxy(host, port, options, pluginID, serviceName) {
   if (!(host && port)) {
-    throw new Error("Proxy: need a host and port");
+    throw new Error(`Proxy (${pluginID}:${serviceName}) setup failed. Host & Port for proxy destination are required but were missing. For information on how to configure a proxy service, see the Zowe wiki on dataservices (https://github.com/zowe/zlux/wiki/ZLUX-Dataservices)`);
   }
   const {urlPrefix, isHttps, addProxyAuthorizations, allowInvalidTLSProxy} = 
     options;

--- a/js/webapp.js
+++ b/js/webapp.js
@@ -475,7 +475,7 @@ WebApp.prototype = {
   
   makeExternalProxy(host, port, urlPrefix, isHttps, noAuth, pluginID, serviceName) {
     const r = express.Router();
-    installLog.info(`Setting up proxy to ${host}:${port}/${urlPrefix}`);
+    installLog.info(`Setting up proxy (${pluginID}:${serviceName}) to destination=${host}:${port}/${urlPrefix}`);
     let myProxy = proxy.makeSimpleProxy(host, port, {
       urlPrefix, 
       isHttps, 
@@ -893,15 +893,18 @@ WebApp.prototype = {
       + ' services')
     const urlBase = zLuxUrl.makePluginURL(this.options.productCode, 
         plugin.identifier);
-    this._installSwaggerCatalog(plugin, urlBase);
-    this._installPluginStaticHandlers(plugin, urlBase);
     try {
+      //dataservices load first since in case of error, we want to skip the rest of the plugin load
       yield *this._installDataServices(pluginContext, urlBase);
+      this._installSwaggerCatalog(plugin, urlBase);
+      this._installPluginStaticHandlers(plugin, urlBase);      
+      //import resolution will be postponed until all non-import plugins are loaded
+      //only push plugin if no exceptions were seen
+      this.plugins.push(plugin);
     } catch (e) {
-      installLog.warn(e.stack);
+      installLog.warn(`Exception occurred, plugin (${plugin.identifier}) installation skipped. Message: ${e.message}`);
+      installLog.debug(e.stack);
     }
-    //import resolution will be postponed until all non-import plugins are loaded
-    this.plugins.push(plugin);
   }),
 
   installErrorHanders() {


### PR DESCRIPTION
Improved logging for what to do when someone forgot to configure a proxy service.

 The message format I changed now prints:

 

[2018-11-27 14:55:10.138 _unp.install INFO] - Setting up proxy (com.zowe.explorer.server.proxy:data) to destination=undefined:undefined/
[2018-11-27 14:55:10.138 _unp.install WARNING] - Exception occurred, plugin (com.zowe.explorer.server.proxy) installation skipped. Message: Proxy (com.zowe.explorer.server.proxy:data) setup failed. Host & Port for proxy destination are required but were missing. For information on how to configure a proxy service, see the Zowe wiki on dataservices (https://github.com/zowe/zlux/wiki/ZLUX-Dataservices)

 

Instead of

 

[2018-11-12 18:12:14.040 _unp.install INFO] - com.zowe.explorer.server.proxy: installing static file handlers...
[2018-11-12 18:12:14.041 _unp.install INFO] - Setting up proxy to undefined:undefined/
[2018-11-12 18:12:14.041 _unp.install WARNING] - Error: Proxy: need a host and port
at Object.makeSimpleProxy (C:_Work\bt\zlux\zlux-proxy-server\js\proxy.js:58:11)
at WebApp.makeExternalProxy (C:_Work\bt\zlux\zlux-proxy-server\js\webapp.js:479:25)
at WebApp._installDataServices (C:_Work\bt\zlux\zlux-proxy-server\js\webapp.js:788:47)
at _installDataServices.next (<anonymous>)
at WebApp.<anonymous> (C:_Work\bt\zlux\zlux-proxy-server\js\webapp.js:891:19)
at Generator.next (<anonymous>)
at Generator.tryCatcher (C:_Work\bt\zlux\zlux-proxy-server\js\node_modules\bluebird\js\release\util.js:16:23)
at PromiseSpawn._promiseFulfilled (C:_Work\bt\zlux\zlux-proxy-server\js\node_modules\bluebird\js\release\generators.js:97:49)
at WebApp.installPlugin (C:_Work\bt\zlux\zlux-proxy-server\js\node_modules\bluebird\js\release\generators.js:201:15)
at Server.pluginLoaded (C:_Work\bt\zlux\zlux-proxy-server\js\index.js:320:24)
at PluginLoader.pluginLoader.on.event (C:_Work\bt\zlux\zlux-proxy-server\js\index.js:251:12)
at PluginLoader.emit (events.js:182:13)
at PluginLoader.loadPlugins (C:_Work\bt\zlux\zlux-proxy-server\js\plugin-loader.js:651:12)
at Server.<anonymous> (C:_Work\bt\zlux\zlux-proxy-server\js\index.js:270:23)
at Generator.next (<anonymous>)
at Generator.tryCatcher (C:_Work\bt\zlux\zlux-proxy-server\js\node_modules\bluebird\js\release\util.js:16:23)
at PromiseSpawn._promiseFulfilled (C:_Work\bt\zlux\zlux-proxy-server\js\node_modules\bluebird\js\release\generators.js:97:49)
at Server.start (C:_Work\bt\zlux\zlux-proxy-server\js\node_modules\bluebird\js\release\generators.js:201:15)
at Object.<anonymous> (C:_Work\bt\zlux\zlux-example-server\js\zluxServer.js:18:13)
at Module._compile (internal/modules/cjs/loader.js:688:30)
at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
at Module.load (internal/modules/cjs/loader.js:598:32)



Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>