### PR TITLE
Missing call to 404 handler if ref header is missing

### DIFF
--- a/js/webapp.js
+++ b/js/webapp.js
@@ -935,6 +935,9 @@ WebApp.prototype = {
             do404(req.url, res, this.options.productCode
             + ": unknown resource requested");
           }
+        } else {
+          do404(req.url, res, this.options.productCode
+                + ": unknown resource requested");
         }
       }
     });


### PR DESCRIPTION
logic for when resource doesnt exist was able to enter a case in which the server would do nothing: neither try to interpret it as a proxied request that escaped the proxy, nor a reference to a missing object.
Solution is just to add do404 to the right place.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>