### PR TITLE
Added conditionally used middleware to add no-caching headers for secure APIs

### DIFF
--- a/plugins/config/pluginDefinition.json
+++ b/plugins/config/pluginDefinition.json
@@ -11,7 +11,8 @@
       "fileName": "configService.js",
       "routerFactory": "configRouter",
       "dependenciesIncluded": true,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "httpCaching":  false
     }
   ]
 }

--- a/plugins/terminal-proxy/pluginDefinition.json
+++ b/plugins/terminal-proxy/pluginDefinition.json
@@ -29,7 +29,8 @@
       "fileName": "terminalProxy.js",
       "routerFactory": "tn3270WebsocketRouter",
       "dependenciesIncluded": true,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "httpCaching":  false
     },
     {
       "type": "router",
@@ -38,7 +39,8 @@
       "fileName": "terminalProxy.js",
       "routerFactory": "tn5250WebsocketRouter",
       "dependenciesIncluded": true,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "httpCaching":  false
     },
     {
       "type": "router",
@@ -47,7 +49,8 @@
       "fileName": "terminalProxy.js",
       "routerFactory": "vtWebsocketRouter",
       "dependenciesIncluded": true,
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "httpCaching":  false
     }
   ]
 }


### PR DESCRIPTION
Resolves https://github.com/zowe/zlux-proxy-server/issues/36
This adds headers to all dataservice calls (unless opt-out at service level or individual call level) which instructs browsers not to cache a response. This is useful for sensitive information or calls that have no need to be cached.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>