### PR TITLE
Fix /plugins showing each plugin twice

### DIFF
--- a/js/webapp.js
+++ b/js/webapp.js
@@ -935,7 +935,6 @@ WebApp.prototype = {
       this._installPluginStaticHandlers(plugin, urlBase);      
       //import resolution will be postponed until all non-import plugins are loaded
       //only push plugin if no exceptions were seen
-      this.plugins.push(plugin);
     } catch (e) {
       //index.js listens and logs, so dont log twice here
       throw e;

--- a/js/webapp.js
+++ b/js/webapp.js
@@ -933,10 +933,9 @@ WebApp.prototype = {
       yield *this._installDataServices(pluginContext, urlBase);
       this._installSwaggerCatalog(plugin, urlBase);
       this._installPluginStaticHandlers(plugin, urlBase);      
-      //import resolution will be postponed until all non-import plugins are loaded
-      //only push plugin if no exceptions were seen
     } catch (e) {
       //index.js listens and logs, so dont log twice here
+      //throw so that plugin isnt pushed to list if there's something wrong with it
       throw e;
     }
     this._resolveImports(plugin, urlBase);


### PR DESCRIPTION
Somehow conflict resolution resulted in this.plugins.push appearing twice in install plugin

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>