### PR TITLE
Versioning/network bugfixes

### DIFF
--- a/js/depgraph.js
+++ b/js/depgraph.js
@@ -5,6 +5,15 @@ const semver = require('semver');
 const zluxUtil = require('./util');
 
 module.exports = DependencyGraph;
+// TODO translation
+module.exports.statuses = {
+  "REQUIRED_PLUGIN_FAILED_TO_LOAD": "Required plugin failed to load",
+  "REQUIRED_PLUGIN_NOT_FOUND": "Required plugin not found",
+  "INVALID_REQUIRED_VERSION_RANGE": "Invalid required version range",
+  "IMPORTED_SERVICE_IS_AN_IMPORT": "Imported service is itself an import",
+  "REQUIRED_SERVICE_VERSION_NOT_FOUND": "Required service version not found",
+  "REQUIRED_SERVICE_NOT_FOUND": "Required service version not found"
+}
 
 const logger = zluxUtil.loggers.bootstrapLogger
 
@@ -232,6 +241,13 @@ function validateDep(dep, providerPlugin) {
       status: "REQUIRED_PLUGIN_NOT_FOUND",
       pluginId: dep.provider
     }
+  } else if (!semver.validRange(dep.requiredVersionRange)) {
+    valid = false;
+    validationError = {
+      status: "INVALID_REQUIRED_VERSION_RANGE",
+      pluginId: dep.provider,
+      requiredVersion: dep.requiredVersionRange
+    }
   } else {
     let found = false;
     let foundAtDifferentVersion = false;
@@ -245,6 +261,8 @@ function validateDep(dep, providerPlugin) {
           }
           found = true;
           break;
+        } else if (!semver.valid(service.version)) {
+          foundAtDifferentVersion = true;
         } else if (!semver.satisfies(service.version, dep.requiredVersionRange)) {
           foundAtDifferentVersion = true;
         } else {

--- a/js/index.js
+++ b/js/index.js
@@ -160,6 +160,7 @@ Server.prototype = {
       }, err => {
         installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
                            +`Message: ${err.message}`);
+        console.log(err)
         installLogger.debug(err.stack);
       });
     }, installLogger));

--- a/js/index.js
+++ b/js/index.js
@@ -160,7 +160,6 @@ Server.prototype = {
       }, err => {
         installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
                            +`Message: ${err.message}`);
-        console.log(err)
         installLogger.debug(err.stack);
       });
     }, installLogger));

--- a/js/plugin-loader.js
+++ b/js/plugin-loader.js
@@ -613,7 +613,8 @@ PluginLoader.prototype = {
     for (const rejectedPlugin of sortedAndRejectedPlugins.rejects) {
       bootstrapLogger.warn(`Could not initialize plugin` 
           + ` ${rejectedPlugin.pluginId}: `  
-          + rejectedPlugin.validationError.status);
+          + zluxUtil.formatErrorStatus(rejectedPlugin.validationError, 
+              DependencyGraph.statuses));
     }
     for (const pluginDef of sortedAndRejectedPlugins.plugins) { 
       try {

--- a/js/plugin-loader.js
+++ b/js/plugin-loader.js
@@ -51,12 +51,6 @@ function Service(def, configuration, plugin) {
   //don't do this here: avoid circular structures:
   //this.plugin = plugin; 
   Object.assign(this, def);
-  if (this.version === undefined) {
-    //FIXME temporary hack until everyone has fixed their plugin defs.
-    bootstrapLogger.warn(`Service ${plugin.identifier}::${this.name} doesn't` 
-      + ` specify a version. Resorting to the plugin's API version ${plugin.apiVersion}`);
-    this.version = plugin.apiVersion;
-  }
 }
 Service.prototype = {
   constructor: Service,

--- a/js/util.js
+++ b/js/util.js
@@ -216,6 +216,18 @@ module.exports.getLoopbackAddress = function getLoopbackAddress(listenerAddresse
   return listenerAddresses[0];
 }
 
+module.exports.formatErrorStatus = function formatErrorStatus(err, descriptions) {
+  const description = (descriptions[err.status] || err.status) + ": ";
+  const keywords = [];
+  
+  for (let key of Object.keys(err)) {
+    if (key == "status") {
+      continue;
+    } 
+    keywords.push(`${key}: ${err[key]}`);
+  }
+  return description + keywords.join(', ');
+}
 
 
 /*

--- a/js/webapp.js
+++ b/js/webapp.js
@@ -480,7 +480,7 @@ const defaultOptions = {
 
 function makeLoopbackConfig(nodeConfig) {
   /* TODO do we really prefer loopback HTTPS? Why not simply choose HTTP? */
-  if (nodeConfig.https) {
+  if (nodeConfig.https && nodeConfig.https.enabled) {
     return {
       port: nodeConfig.https.port,
       isHttps: true,
@@ -552,6 +552,7 @@ WebApp.prototype = {
   
   makeProxy(urlPrefix, noAuth) {
     const r = express.Router();
+   // console.log("makeProxy", this.options)
     r.use(proxy.makeSimpleProxy(this.options.proxiedHost, this.options.proxiedPort, 
     {
       urlPrefix, 
@@ -892,7 +893,7 @@ WebApp.prototype = {
           [importedService.sourceName][importedService.version];
         if (!importedRouter) {
           throw new Error(
-            `Import ${importedService.sourcePlugin}:${implortedService.sourceName}`
+            `Import ${importedService.sourcePlugin}:${importedService.sourceName}`
             + " can't be satisfied");
         }
         installLog.info(`${plugin.identifier}: installing import`

--- a/js/webapp.js
+++ b/js/webapp.js
@@ -552,7 +552,6 @@ WebApp.prototype = {
   
   makeProxy(urlPrefix, noAuth) {
     const r = express.Router();
-   // console.log("makeProxy", this.options)
     r.use(proxy.makeSimpleProxy(this.options.proxiedHost, this.options.proxiedPort, 
     {
       urlPrefix, 

--- a/js/webserver.js
+++ b/js/webserver.js
@@ -101,20 +101,28 @@ WebServer.prototype = {
       if (uniqueIps.length > 0) {
         canRun = true;
         networkLogger.info('HTTP config valid, will listen on: ' + uniqueIps);
+        config.http.enabled = true;
       }
       config.http.ipAddresses = uniqueIps;
     } 
+    /* TODO this 'canRun' logic has long been here, but I'm wondering if is's
+     * adequate: I think we might want to make sure that everything 
+     * the user requested is doable, not just something. If either HTTP or HTTPS
+     * was requested and we couldn't start it, then we might want to signal an
+     * error, rather than trying to chug along somehow... */
     if (config.https && config.https.port) {
       const uniqueIps =  yield util.uniqueIps(config.https.ipAddresses);
       if (uniqueIps.length > 0) {
         if (config.https.pfx) {
           canRun = true;
           networkLogger.info('HTTPS config valid, will listen on: ' + uniqueIps);
+          config.https.enabled = true;
         } else if (config.https.certificates && config.https.keys) {
           canRun = true;
           networkLogger.info('HTTPS config valid, will listen on: ' + uniqueIps);
+          config.https.enabled = true;
         }
-      }
+      } 
       config.https.ipAddresses = uniqueIps;
     }
     return canRun;


### PR DESCRIPTION
- Proper depgraph error message formatting
- Avoid semver exceptions
- stop using the plugin's API version as a fallback for service versions
- use HTTP for loopback if all specified HTTPS listener addresses are
invalid